### PR TITLE
Rewrote plugin to not rely on usermeta

### DIFF
--- a/pmpro-stripe-billing-limits.php
+++ b/pmpro-stripe-billing-limits.php
@@ -7,155 +7,110 @@ Version: .3
 Author: Paid Memberships Pro
 Author URI: https://www.paidmembershipspro.com
 */
-/*
-	The Plan
-	* Hook into pmpro_after_checkout
-	* If $level->billing_limit > 0 and gateway == stripe, save user meta with level id, Stripe sub id, billing limits #
-	
-	* Hook into new recurring order created.
-	* Check for user meta RE billing limits.
-	* Check if X successful payments have been made within the same sub id.
-	* If so, cancel the subscription. BUT NOT the membership.
-	
-	* Going to leave the built-in PMPro warnings for now.
-  * 3/4/19 - updated to use new Stripe API methods
-*/
-//save some user meta after checkout to track billing limit
-function pmprosbl_pmpro_after_checkout($user_id)
-{
-	//what level?
-	global $pmpro_level, $gateway;
-	
-	//get order
-	$order = new MemberOrder();
-	$order->getLastMemberOrder($user_id);
-	
-	//billing limit? gateway stripe?
-	if($pmpro_level->billing_limit > 0 && $order->gateway == "stripe")
-	{
-	
-	  //subscription id is on the order
-		$subscription_id = $order->subscription_transaction_id;
-		
-		//customer id is in user meta
-		$customer_id = get_user_meta($user_id, "pmpro_stripe_customerid", true);
-			
-		
-		//no sub ID or customer ID? return
-		if(!empty($subscription_id) && !empty($customer_id))
-		{		
-		
-			//build array to save
-			$pmpro_stripe_billing_limit = array(
-				'user_id' => $user_id,			
-				'level_id' => $pmpro_level->id,
-				'billing_limit' => $pmpro_level->billing_limit,
-				'customer_id' => $customer_id,
-				'subscription_id' => $subscription_id,
-				'payments' => 0	//start with 0
-			);
-			
-			//save it
-			update_user_meta($user_id, "pmpro_stripe_billing_limit", $pmpro_stripe_billing_limit);
-			
-			return;
-		}
+
+/**
+ * When an order is saved, check if we've reached the billing limit for the subscription.
+ * If so, cancel the subscription in Stripe.
+ *
+ * @since TBD
+ *
+ * @param MemberOrder $order The order object.
+ */
+function pmprosbl_pmpro_added_order( $order ) {
+	// If we haven't reached the billing limit for this order, we don't need to do anything here.
+	if ( ! pmprosbl_is_billing_limit_reached( $order ) ) {
+		return;
 	}
-	
-	//if we got here, make sure to clear out any old billing limit
-	delete_user_meta($user_id, "pmpro_stripe_billing_limit");
-}
-add_action('pmpro_after_checkout', 'pmprosbl_pmpro_after_checkout');
-//check billing limit with each new order
-function pmprosbl_pmpro_added_order($order)
-{
-	//new stripe order?
-	if($order->gateway == "stripe")
-	{
-		//billing limit on this one?
-		$pmpro_stripe_billing_limit = get_user_meta($order->user_id, "pmpro_stripe_billing_limit", true);
-		
-		if(!empty($pmpro_stripe_billing_limit))
-		{
-			//update the # of payments
-			$pmpro_stripe_billing_limit['payments']++;
-			
-			//hit limit?
-			if(empty($pmpro_stripe_billing_limit['cancelled']) && $pmpro_stripe_billing_limit['payments'] >= $pmpro_stripe_billing_limit['billing_limit'])
-			{
-				//cancel the subscription
-				try
-				{
-					$customer = Stripe\Customer::retrieve($pmpro_stripe_billing_limit['customer_id']);
-					$subscription = $customer->subscriptions->retrieve($pmpro_stripe_billing_limit['subscription_id']);
-					$subscription->cancel();
-				}
-				catch (Exception $e)
-				{
-					// customer or subscription already deleted on stripe's end, we don't need to do anything here
-				}
-				//make sure we don't try to cancel again
-				$pmpro_stripe_billing_limit['cancelled'] = true;
-			}
-			update_user_meta($order->user_id, "pmpro_stripe_billing_limit", $pmpro_stripe_billing_limit);
-		}
+
+	// Billing limit has been reached, so cancel the subscription.
+	$stripe = new PMProGateway_stripe(); // Make sure that Stripe is loaded.
+	try {
+		$subscription = \Stripe\Subscription::retrieve( $order->subscription_transaction_id );
+		$subscription->cancel();
+	} catch ( Exception $e ) {
+		// There was an error. Let's not do anything for now.
 	}
+
+	// Clean up old "pmpro_stripe_billing_limit" metadata from old versions of this plugin.
+	delete_user_meta( $order->user_id, 'pmpro_stripe_billing_limit' );
 }
 add_action('pmpro_added_order', 'pmprosbl_pmpro_added_order');
-//don't do anything when a stripe subscription is deleted if the user had a billing limit
-function pmprosbl_pmpro_stripe_subscription_deleted($user_id)
-{
-	//billing limit?
-	$pmpro_stripe_billing_limit = get_user_meta($user_id, "pmpro_stripe_billing_limit", true);
-	
-	if(!empty($pmpro_stripe_billing_limit) && !empty($pmpro_stripe_billing_limit['cancelled']))
-	{	
-		global $logstr;
-		$logstr .= "Subscription user ID #" . $user_id . " has hit its billing limit. Subscription deleted.";
-		pmpro_stripeWebhookExit();
-	}
-}
-add_action('pmpro_stripe_subscription_deleted', 'pmprosbl_pmpro_stripe_subscription_deleted', 1);
+add_action('pmpro_updated_order', 'pmprosbl_pmpro_added_order');
 
-/*
-	Get a Stripe Subscription for customer with id = customer_id and plan = plan_id.
-	If no plan_id is given, the first subscription will be returned.
-*/
-function pmprosbl_getStripeSubscription($customer_id, $plan_id = false)
-{
-	//make sure Stripe is loaded
-	if(!class_exists("Stripe"))
-		require_once(PMPRODIR . "/includes/lib/Stripe/Stripe.php");
-		
-	//find the customer
-	$stripe = new PMProGateway_stripe("stripe");
-	
-	$customer = Stripe_Customer::retrieve($customer_id);
-				
-	if(!empty($customer))
-	{
-		//find subscription with this order code
-		$subscriptions = $customer->subscriptions->all();												
-							
-		if(!empty($subscriptions))
-		{					
-			//no plan given? return the first
-			if(empty($plan_id))
-				return $subscriptions->data[0];
-			
-			//find sub with the same plan id
-			foreach($subscriptions->data as $sub)
-			{						
-				if($sub->plan->id == $plan_id)
-				{
-					//found it
-					return $sub;
-				}
-			}
-		}
+/**
+ * When a subcsription is deleted in Stripe, check if we deleted it because of a billing limit.
+ * If so, we don't want to cancel the user's membership.
+ *
+ * @since TBD
+ *
+ * @param int $user_id The user ID.
+ */
+function pmprosbl_pmpro_stripe_subscription_deleted( $user_id ) {
+	// Unfortunately, we don't have a way to get the subscription being deleted in this hook.
+	// So let's get the user's most recent successful stripe order and assume that's the one being deleted.
+	// This should be safe since we only cancel subscriptions when an order is saved that passes the billing limit.
+	$order = new MemberOrder();
+	$order->getLastMemberOrder( $user_id, 'success', NULL, 'stripe' );
+
+	// If we haven't reached the billing limit for this order, we should let the membership be cancelled as normal.
+	if ( ! pmprosbl_is_billing_limit_reached( $order ) ) {
+		return;
 	}
-	
-	return false;
+
+	// We deleted this subscription because of a billing limit, so we don't want to cancel the user's membership.
+	// Let's log a messsage and exit the webhook handler.
+	global $logstr;
+	$logstr .= "Subscription user ID #" . $user_id . " has hit its billing limit. Subscription deleted.";
+	pmpro_stripeWebhookExit();
+}
+add_action( 'pmpro_stripe_subscription_deleted', 'pmprosbl_pmpro_stripe_subscription_deleted', 1 );
+
+/**
+ * Helper function to check if the billing limit has been reached for a given Stripe order.
+ *
+ * @since TBD
+ *
+ * @param MemberOrder $order The order object.
+ * @return bool True if the billing limit has been reached, false otherwise.
+ */
+function pmprosbl_is_billing_limit_reached( $order ) {
+	// Check if this is a Stripe order.
+	if ( 'stripe' !== $order->gateway ) {
+		return false;
+	}
+
+	// Check if this order was successful.
+	if ( 'success' !== $order->status ) {
+		return false;
+	}
+
+	// Check if this order has a subscription ID.
+	if ( empty( $order->subscription_transaction_id ) ) {
+		return false;
+	}
+
+	// Make sure that this order has a user ID.
+	if ( empty( $order->user_id ) ) {
+		return false;
+	}
+
+	// Check if the level for this order has a billing limit.
+	$level = $order->getMembershipLevel();
+	if ( empty( $level ) || empty( $level->billing_limit ) ) {
+		return false;
+	}
+
+	// Get the number of successful payments for this subscription.
+	global $wpdb;
+	$order_count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->pmpro_membership_orders WHERE gateway = 'stripe' AND status = 'success' AND subscription_transaction_id = %s AND user_id = %s", $order->subscription_transaction_id, $order->user_id ) );
+
+	// Check if we are still below the limit.
+	// Note that the initial pamyent is counted in the order count, but not the billing limit. So if these are equal, we shouldn't cancel the subscription yet.
+	if ( $order_count <= $level->billing_limit ) {
+		return false;
+	}
+
+	return true;
 }
 
 /**
@@ -167,8 +122,8 @@ function pmprosbl_getStripeSubscription($customer_id, $plan_id = false)
 function pmprosbl_plugin_row_meta( $links, $file ) {
  	if ( strpos( $file, 'pmpro-stripe-billing-limits.php' ) !== false ) {
  		$new_links = array(
- 			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/pmpro-stripe-billing-limits/' ) . '" title="' . esc_attr( __( 'View Documentation', 'pmpro-stripe-billing-limits' ) ) . '">' . __( 'Docs', 'pmpro-stripe-billing-limits' ) . '</a>',
- 			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/support/' ) . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro-stripe-billing-limits' ) ) . '">' . __( 'Support', 'pmpro-stripe-billing-limits' ) . '</a>',
+ 			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/pmpro-stripe-billing-limits/' ) . '" title="' . esc_attr( __( 'View Documentation', 'pmpro-stripe-billing-limits' ) ) . '">' . esc_html__( 'Docs', 'pmpro-stripe-billing-limits' ) . '</a>',
+ 			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/support/' ) . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro-stripe-billing-limits' ) ) . '">' . esc_html__( 'Support', 'pmpro-stripe-billing-limits' ) . '</a>',
  		);
  		$links = array_merge( $links, $new_links );
  	}


### PR DESCRIPTION
The current version of this Add On relies on user meta to track the billing limit of the user's current subscription and the number of payments that have been made. This approach relies on that metadata being correctly set up at checkout and correctly updated each time that a payment is made, and can easily be thrown off in cases where the plugin is disabled, an error is thrown, etc.

Additionally, the current approach is not MMPU-compatible.

The fix proposed in this PR changes the plugin to instead check whether a billing limit has been reached by pulling the billing limit for the user's specific level and counting the number of orders that are present for the subscription on the website.